### PR TITLE
Fix bug where an issue doesn't have a store_date

### DIFF
--- a/Simyan/issue/issue.py
+++ b/Simyan/issue/issue.py
@@ -37,7 +37,7 @@ class IssueSchema(Schema):
     object_credits = fields.Nested(item.ItemEntrySchema, many=True)
     person_credits = fields.Nested(people.PeopleEntrySchema, many=True)
     site_url = fields.Url(data_key='site_detail_url')
-    store_date = fields.Date(format="%Y-%m-%d")
+    store_date = fields.Date(format="%Y-%m-%d", allow_none=True)
     story_arc_credits = fields.Nested(StoryArcEntrySchema, many=True)
     team_credits = fields.Nested(team.TeamEntrySchema, many=True)
     team_disbanded_in = fields.Nested(team.TeamEntrySchema, many=True)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 
 from Simyan import APIError
@@ -27,3 +29,15 @@ def test_issue_list(talker):
 def test_issue_list_empty(talker):
     results = talker.issue_list({'filter': 'name:INVALID'})
     assert len(results) == 0
+
+def test_issue_bad_cover_date(talker):
+    xmen_2 = talker.issue(6787)
+    assert xmen_2.store_date is None
+    assert xmen_2.cover_date == datetime.date(1963, 11, 1)
+    assert xmen_2.id == 6787
+    assert xmen_2.issue_number == "2"
+    assert len(xmen_2.person_credits) == 4
+    assert xmen_2.person_credits[0].name == "Jack Kirby"
+    assert xmen_2.person_credits[0].role == "penciler"
+    assert len(xmen_2.character_credits) == 10
+    assert xmen_2.character_credits[0].name == "Angel"


### PR DESCRIPTION
Some issues at Comic Vine don't have a store_date (in particular older issues), and currently the Issue Schema doesn't handle this correctly. Here's a simple fix and a test to verify it works.